### PR TITLE
Bryn/fix map set generics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.3 - 2022-03-30
+### Fixed
+[#1](https://github.com/BrynCooke/buildstructor/issues/1) Fix generics on collections
 
 ## 0.1.2 - 2022-03-30
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["derive", "macro", "builder", "constructor"]
 
 [lib]
 proc-macro = true
+doctest = false
 
 [dependencies]
 lazy_static = "1.4.0"

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ To create a fallible builder just make your constructor fallible using `Result`.
 ```rust
 #[builder]
 impl MyStruct {
-    fn new(param: Option<usize>) -> Result<MyStruct, Box<dyn Error>> {
+    fn new(param: usize) -> Result<MyStruct, Box<dyn Error>> {
         Ok(Self { param })
     }
 }

--- a/examples/collections_generics.rs
+++ b/examples/collections_generics.rs
@@ -1,0 +1,45 @@
+use std::collections::{HashMap, HashSet};
+
+use buildstructor::builder;
+
+pub struct Collections {
+    map: HashMap<String, String>,
+    set: HashSet<String>,
+}
+
+#[builder]
+impl Collections {
+    fn new<K: Into<String>, V: Into<String>>(map: HashMap<K, V>, set: HashSet<K>) -> Collections {
+        Self {
+            map: map.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
+            set: set.into_iter().map(|v| v.into()).collect(),
+        }
+    }
+}
+
+fn main() {
+    let collections = Collections::builder()
+        .map_entry("Appa", "1")
+        .map_entry("Momo", "2")
+        .set_entry("Aang")
+        .set_entry("Katara")
+        .set_entry("Sokka")
+        .set_entry("Toph")
+        .build();
+    assert_eq!(
+        collections.map,
+        HashMap::from([
+            ("Appa".to_string(), "1".to_string()),
+            ("Momo".to_string(), "2".to_string())
+        ])
+    );
+    assert_eq!(
+        collections.set,
+        HashSet::from([
+            ("Aang".to_string()),
+            ("Katara".to_string()),
+            ("Sokka".to_string()),
+            ("Toph".to_string()),
+        ])
+    );
+}

--- a/src/buildstructor/analyze.rs
+++ b/src/buildstructor/analyze.rs
@@ -107,4 +107,9 @@ mod tests {
     fn collection_test() {
         analyze(collections_test_case()).unwrap();
     }
+
+    #[test]
+    fn collection_generics_test() {
+        analyze(collections_generics_test_case()).unwrap();
+    }
 }

--- a/src/buildstructor/mod.rs
+++ b/src/buildstructor/mod.rs
@@ -139,4 +139,20 @@ mod tests {
             }
         )
     }
+
+    pub fn collections_generics_test_case() -> Ast {
+        parse_quote!(
+            #[builder]
+            impl Foo {
+                fn new<K: Into<String>, V: Into<String>>(param: HashMap<K, V>) -> Foo {
+                    Self {
+                        param: param
+                            .into_iter()
+                            .map(|(k, v)| (k.into(), v.into()))
+                            .collect(),
+                    }
+                }
+            }
+        )
+    }
 }

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_generics_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_generics_test.snap
@@ -1,0 +1,96 @@
+---
+source: src/buildstructor/codegen.rs
+expression: output
+---
+impl Foo {
+    fn builder<K: Into<String>, V: Into<String>>() -> __foo_builder::__FooBuilder<
+            (__Optional<HashMap<K, V>>,),
+            K,
+            V,
+        > {
+        __foo_builder::new()
+    }
+}
+use __foo_builder::*;
+mod __foo_builder {
+    use super::*;
+    pub fn new<K: Into<String>, V: Into<String>>() -> __FooBuilder<
+            (__Optional<HashMap<K, V>>,),
+            K,
+            V,
+        > {
+        __FooBuilder {
+            fields: (__optional(),),
+            phantom: core::default::Default::default(),
+        }
+    }
+    pub struct __Required<T> {
+        phantom: std::marker::PhantomData<T>,
+    }
+    pub struct __Optional<T> {
+        lazy: Option<T>,
+    }
+    pub struct __Set<T> {
+        value: T,
+    }
+    fn __set<T>(value: T) -> __Set<T> {
+        __Set { value }
+    }
+    fn __required<T>() -> __Required<T> {
+        __Required::<T> {
+            phantom: core::default::Default::default(),
+        }
+    }
+    fn __optional<T>() -> __Optional<T> {
+        __Optional::<T> { lazy: None }
+    }
+    impl<T: Default> From<__Optional<T>> for __Set<T> {
+        fn from(o: __Optional<T>) -> Self {
+            __Set {
+                value: o.lazy.unwrap_or_default(),
+            }
+        }
+    }
+    pub struct __FooBuilder<__P, K, V> {
+        fields: __P,
+        phantom: (core::marker::PhantomData<K>, core::marker::PhantomData<V>),
+    }
+    impl<
+        K: Into<String> + core::cmp::Eq + core::hash::Hash,
+        V: Into<String>,
+    > __FooBuilder<(__Optional<HashMap<K, V>>,), K, V> {
+        pub fn param(
+            mut self,
+            param: HashMap<K, V>,
+        ) -> __FooBuilder<(__Optional<HashMap<K, V>>,), K, V> {
+            self.fields
+                .0
+                .lazy
+                .get_or_insert_with(|| core::default::Default::default())
+                .extend(param.into_iter());
+            self
+        }
+        pub fn param_entry(
+            mut self,
+            key: K,
+            value: V,
+        ) -> __FooBuilder<(__Optional<HashMap<K, V>>,), K, V> {
+            self.fields
+                .0
+                .lazy
+                .get_or_insert_with(|| core::default::Default::default())
+                .insert(key, value);
+            self
+        }
+    }
+    impl<
+        K: Into<String>,
+        V: Into<String>,
+        __P0: Into<__Set<HashMap<K, V>>>,
+    > __FooBuilder<(__P0,), K, V> {
+        pub fn build(self) -> Foo {
+            Foo::new(self.fields.0.into().value)
+        }
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,10 +33,9 @@ use crate::buildstructor::parse;
 ///     }
 /// }
 ///
-/// fn main() {
-///     let mine = MyStruct::builder().a(2).b(3).build();
-///     assert_eq!(mine.sum, 5);
-/// }
+/// let mine = MyStruct::builder().a(2).b(3).build();
+/// assert_eq!(mine.sum, 5);
+///
 /// ```
 #[proc_macro_attribute]
 pub fn builder(attr: TokenStream, item: TokenStream) -> TokenStream {


### PR DESCRIPTION
Fixes missing comma in generics.
Adds `Eq` and `Hash` requirement for key in Maps and value in Sets.