### PR TITLE
Bryn/fix map set generics again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.4 - 2022-03-30
+### Fixed
+[#6](https://github.com/BrynCooke/buildstructor/issues/6) Fix generics on collections.
+This mostly rolls back the changes in [#1](https://github.com/BrynCooke/buildstructor/issues/1). THe examples have been updated to show the correct way to use into with a collection.
+
 ## 0.1.3 - 2022-03-30
 ### Fixed
 [#1](https://github.com/BrynCooke/buildstructor/issues/1) Fix generics on collections

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buildstructor"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Bryn Cooke <bryncooke@gmail.com>"]
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buildstructor"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Bryn Cooke <bryncooke@gmail.com>"]
 license = "Apache-2.0"

--- a/examples/collections_generics.rs
+++ b/examples/collections_generics.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
 
 use buildstructor::builder;
 
@@ -9,7 +10,10 @@ pub struct Collections {
 
 #[builder]
 impl Collections {
-    fn new<K: Into<String>, V: Into<String>>(map: HashMap<K, V>, set: HashSet<K>) -> Collections {
+    fn new<K: Into<String> + Eq + Hash, V: Into<String>>(
+        map: HashMap<K, V>,
+        set: HashSet<K>,
+    ) -> Collections {
         Self {
             map: map.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
             set: set.into_iter().map(|v| v.into()).collect(),

--- a/examples/collections_option.rs
+++ b/examples/collections_option.rs
@@ -1,0 +1,28 @@
+use std::collections::HashMap;
+
+use buildstructor::builder;
+
+pub struct Collections {
+    map: HashMap<Option<String>, Option<String>>,
+}
+
+#[builder]
+impl Collections {
+    fn new(map: HashMap<Option<String>, Option<String>>) -> Collections {
+        Self { map }
+    }
+}
+
+fn main() {
+    let collections = Collections::builder()
+        .map_entry(Some("Appa".to_string()), Some("1".to_string()))
+        .map_entry(Some("Momo".to_string()), Some("2".to_string()))
+        .build();
+    assert_eq!(
+        collections.map,
+        HashMap::from([
+            (Some("Appa".to_string()), Some("1".to_string())),
+            (Some("Momo".to_string()), Some("2".to_string()))
+        ])
+    );
+}

--- a/src/buildstructor/codegen.rs
+++ b/src/buildstructor/codegen.rs
@@ -163,10 +163,7 @@ pub fn builder_methods(ir: &Ir) -> Result<Vec<TokenStream>> {
             let new_state = params(ir, idx, field_name, &builder_type_generics, set);
             let set_some = call(format_ident!("__set"), vec![call(format_ident!("Some"), vec![Expr::Path(field_name.to_expr_path())])]);
             let new_state_option = params(ir, idx, field_name, &builder_type_generics, set_some);
-
-
-            let mut builder_type_generics = Generics::combine(vec![&builder_type_generics.without(idx), &builder_generics]);
-
+            let builder_type_generics = Generics::combine(vec![&builder_type_generics.without(idx), &builder_generics]);
             let generic_param = ty.generic_args();
 
             match f.field_type {
@@ -191,11 +188,8 @@ pub fn builder_methods(ir: &Ir) -> Result<Vec<TokenStream>> {
                 },
                 FieldType::Set => {
                     let (singular, plural) = single_plural_names(field_name);
-                    let field_collection_type = &f.collection_type.as_ref().unwrap().raw_ident().unwrap();
+                    let field_collection_type = &f.collection_type;
                     let index = Index::from(idx);
-                    builder_type_generics = builder_type_generics.add_bound(field_collection_type, &Type::parse("core::cmp::Eq"))
-                        .add_bound(field_collection_type, &Type::parse("core::hash::Hash"));
-
                     quote! {
                         impl #builder_type_generics #builder_name #before {
 
@@ -234,11 +228,9 @@ pub fn builder_methods(ir: &Ir) -> Result<Vec<TokenStream>> {
                 },
                 FieldType::Map => {
                     let (singular, plural) = single_plural_names(field_name);
-                    let field_key_type = &f.key_type.as_ref().unwrap().raw_ident().unwrap();
+                    let field_key_type = &f.key_type;
                     let field_value_type = &f.value_type;
                     let index = Index::from(idx);
-                    builder_type_generics = builder_type_generics.add_bound(field_key_type, &Type::parse("core::cmp::Eq"))
-                        .add_bound(field_key_type, &Type::parse("core::hash::Hash"));
                     quote! {
                         impl #builder_type_generics #builder_name #before {
 
@@ -385,5 +377,10 @@ mod tests {
     #[test]
     fn collection_generics_test() {
         assert_codegen!(collections_generics_test_case());
+    }
+
+    #[test]
+    fn collection_option_test() {
+        assert_codegen!(collections_option_test_case());
     }
 }

--- a/src/buildstructor/mod.rs
+++ b/src/buildstructor/mod.rs
@@ -144,7 +144,23 @@ mod tests {
         parse_quote!(
             #[builder]
             impl Foo {
-                fn new<K: Into<String>, V: Into<String>>(param: HashMap<K, V>) -> Foo {
+                fn new<K: Into<String> + Eq + Hash, V: Into<String>>(param: HashMap<K, V>) -> Foo {
+                    Self {
+                        param: param
+                            .into_iter()
+                            .map(|(k, v)| (k.into(), v.into()))
+                            .collect(),
+                    }
+                }
+            }
+        )
+    }
+
+    pub fn collections_option_test_case() -> Ast {
+        parse_quote!(
+            #[builder]
+            impl Foo {
+                fn new(param: HashMap<Option<String>, Option<String>>) -> Foo {
                     Self {
                         param: param
                             .into_iter()

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_option_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_option_test.snap
@@ -3,10 +3,8 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo {
-    fn builder<K: Into<String> + Eq + Hash, V: Into<String>>() -> __foo_builder::__FooBuilder<
-            (__Optional<HashMap<K, V>>,),
-            K,
-            V,
+    fn builder() -> __foo_builder::__FooBuilder<
+            (__Optional<HashMap<Option<String>, Option<String>>>,),
         > {
         __foo_builder::new()
     }
@@ -14,10 +12,8 @@ impl Foo {
 use __foo_builder::*;
 mod __foo_builder {
     use super::*;
-    pub fn new<K: Into<String> + Eq + Hash, V: Into<String>>() -> __FooBuilder<
-            (__Optional<HashMap<K, V>>,),
-            K,
-            V,
+    pub fn new() -> __FooBuilder<
+            (__Optional<HashMap<Option<String>, Option<String>>>,),
         > {
         __FooBuilder {
             fields: (__optional(),),
@@ -51,18 +47,15 @@ mod __foo_builder {
             }
         }
     }
-    pub struct __FooBuilder<__P, K, V> {
+    pub struct __FooBuilder<__P> {
         fields: __P,
-        phantom: (core::marker::PhantomData<K>, core::marker::PhantomData<V>),
+        phantom: (),
     }
-    impl<
-        K: Into<String> + Eq + Hash,
-        V: Into<String>,
-    > __FooBuilder<(__Optional<HashMap<K, V>>,), K, V> {
+    impl __FooBuilder<(__Optional<HashMap<Option<String>, Option<String>>>,)> {
         pub fn param(
             mut self,
-            param: HashMap<K, V>,
-        ) -> __FooBuilder<(__Optional<HashMap<K, V>>,), K, V> {
+            param: HashMap<Option<String>, Option<String>>,
+        ) -> __FooBuilder<(__Optional<HashMap<Option<String>, Option<String>>>,)> {
             self.fields
                 .0
                 .lazy
@@ -72,9 +65,9 @@ mod __foo_builder {
         }
         pub fn param_entry(
             mut self,
-            key: K,
-            value: V,
-        ) -> __FooBuilder<(__Optional<HashMap<K, V>>,), K, V> {
+            key: Option<String>,
+            value: Option<String>,
+        ) -> __FooBuilder<(__Optional<HashMap<Option<String>, Option<String>>>,)> {
             self.fields
                 .0
                 .lazy
@@ -84,10 +77,8 @@ mod __foo_builder {
         }
     }
     impl<
-        K: Into<String> + Eq + Hash,
-        V: Into<String>,
-        __P0: Into<__Set<HashMap<K, V>>>,
-    > __FooBuilder<(__P0,), K, V> {
+        __P0: Into<__Set<HashMap<Option<String>, Option<String>>>>,
+    > __FooBuilder<(__P0,)> {
         pub fn build(self) -> Foo {
             Foo::new(self.fields.0.into().value)
         }


### PR DESCRIPTION
Special casing the collection handling made things much worse.

Reverted this code and fixed the example.

The solution is to put `Eq` and `Hash` as constraints on the key in the constructor definition.
```rust
  fn new<K: Into<String> + Eq + Hash, V: Into<String>>(
        map: HashMap<K, V>,
     
    ) -> Collections {
        Self {
            map: map.into_iter().map(|(k, v)| (k.into(), v.into())).collect(),
        }
    }
```

Need to think harder about how to supply decent error messages.

