### PR TITLE
Add a couple of error cases to the tests.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-rust 1.60.0
+rust stable

--- a/tests/buildstructor/fail/duplicate.rs
+++ b/tests/buildstructor/fail/duplicate.rs
@@ -1,0 +1,15 @@
+use buildstructor::builder;
+pub struct Foo {
+    simple: String,
+}
+
+#[builder]
+impl Foo {
+    fn new(simple: String) -> Foo {
+        Self { simple }
+    }
+}
+
+fn main() {
+    let _ = Foo::builder().simple("3").simple("3").build();
+}

--- a/tests/buildstructor/fail/duplicate.stderr
+++ b/tests/buildstructor/fail/duplicate.stderr
@@ -1,0 +1,11 @@
+error[E0599]: no method named `simple` found for struct `__FooBuilder<(__Set<String>,)>` in the current scope
+  --> tests/buildstructor/fail/duplicate.rs:14:40
+   |
+6  | #[builder]
+   | ---------- method `simple` not found for this
+...
+14 |     let _ = Foo::builder().simple("3").simple("3").build();
+   |                                        ^^^^^^ method not found in `__FooBuilder<(__Set<String>,)>`
+   |
+   = note: the method was found for
+           - `__FooBuilder<(__Required<String>,)>`

--- a/tests/buildstructor/fail/missing.rs
+++ b/tests/buildstructor/fail/missing.rs
@@ -1,0 +1,15 @@
+use buildstructor::builder;
+pub struct Foo {
+    simple: String,
+}
+
+#[builder]
+impl Foo {
+    fn new(simple: String) -> Foo {
+        Self { simple }
+    }
+}
+
+fn main() {
+    let _ = Foo::builder().build();
+}

--- a/tests/buildstructor/fail/missing.stderr
+++ b/tests/buildstructor/fail/missing.stderr
@@ -1,0 +1,15 @@
+error[E0599]: the method `build` exists for struct `__FooBuilder<(__Required<String>,)>`, but its trait bounds were not satisfied
+   --> tests/buildstructor/fail/missing.rs:14:28
+    |
+6   | #[builder]
+    | ----------
+    | |
+    | method `build` not found for this
+    | doesn't satisfy `__Required<String>: Into<__Set<String>>`
+...
+14  |     let _ = Foo::builder().build();
+    |                            ^^^^^ method cannot be called on `__FooBuilder<(__Required<String>,)>` due to unsatisfied trait bounds
+    |
+    = note: the following trait bounds were not satisfied:
+            `__Required<String>: Into<__Set<String>>`
+note: the following trait must be implemented


### PR DESCRIPTION
Honestly the error messages are not great, and this is where typedbuilder is much better. I think it uses depricated methods give nice messages on what can and cannot be called.