### PR TITLE
Generally improve the entry point code in prep for helper attributes.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-rust stable
+rust 1.60.0

--- a/src/buildstructor/analyze.rs
+++ b/src/buildstructor/analyze.rs
@@ -16,7 +16,7 @@ pub struct ConstrutorModel {
     pub vis: Visibility,
 }
 
-pub fn analyze(ast: Ast) -> Result<Vec<ConstrutorModel>> {
+pub fn analyze(ast: &Ast) -> Result<Vec<ConstrutorModel>> {
     let constructors = get_constructors(&ast.item);
     let ident = ast
         .item
@@ -65,56 +65,56 @@ mod tests {
 
     #[test]
     fn single_field_test() {
-        analyze(single_field_test_case()).unwrap();
+        analyze(&single_field_test_case()).unwrap();
     }
 
     #[test]
     fn pub_test() {
-        analyze(pub_test_case()).unwrap();
+        analyze(&pub_test_case()).unwrap();
     }
 
     #[test]
     fn multi_field_test() {
-        analyze(multi_field_test_case()).unwrap();
+        analyze(&multi_field_test_case()).unwrap();
     }
 
     #[test]
     fn generic_test() {
-        analyze(generic_test_case()).unwrap();
+        analyze(&generic_test_case()).unwrap();
     }
 
     #[test]
     fn async_test() {
-        analyze(async_test_case()).unwrap();
+        analyze(&async_test_case()).unwrap();
     }
 
     #[test]
     fn fallible_test() {
-        analyze(fallible_test_case()).unwrap();
+        analyze(&fallible_test_case()).unwrap();
     }
 
     #[test]
     fn into_test() {
-        analyze(into_test_case()).unwrap();
+        analyze(&into_test_case()).unwrap();
     }
 
     #[test]
     fn into_where_test() {
-        analyze(into_where_test_case()).unwrap();
+        analyze(&into_where_test_case()).unwrap();
     }
 
     #[test]
     fn option_test() {
-        analyze(option_test_case()).unwrap();
+        analyze(&option_test_case()).unwrap();
     }
 
     #[test]
     fn collection_test() {
-        analyze(collections_test_case()).unwrap();
+        analyze(&collections_test_case()).unwrap();
     }
 
     #[test]
     fn collection_generics_test() {
-        analyze(collections_generics_test_case()).unwrap();
+        analyze(&collections_generics_test_case()).unwrap();
     }
 }

--- a/src/buildstructor/codegen.rs
+++ b/src/buildstructor/codegen.rs
@@ -397,7 +397,7 @@ mod tests {
 
     macro_rules! assert_codegen {
         ($input:expr) => {
-            let models = analyze($input).expect("Analysis failed");
+            let models = analyze(&$input).expect("Analysis failed");
             for model in models {
                 let ir = lower(model).expect("Ir failed");
                 if let Ok(codegen) = codegen(ir) {


### PR DESCRIPTION
Error handling has been improved so that individual constructors will not fail the entire macro.
In addition there is now a spot where we can sanitize the AST for helper attributes in future.