### PR TITLE
release-0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buildstructor"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Bryn Cooke <bryncooke@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION

[#55](https://github.com/BrynCooke/buildstructor/issues/55)
Lifetimes are supported now.

[#52](https://github.com/BrynCooke/buildstructor/issues/52)
Add docs to generated builder.
In addition, a type alias is introduced for the initial builder type so that:
1. the docs looks nice
2. the builder can be passed to a function (although this is of limited real world use).

[#4](https://github.com/BrynCooke/buildstructor/issues/4)
Use `#[inline(always)]` on generated code.
