### PR TITLE
Use MaybeUninit to represent unset but required variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.3 - Unreleased
+
+[#3](https://github.com/BrynCooke/buildstructor/issues/3)
+Changed the storage of required but not yet supplied values to use MaybeUninit.
+The tuple that represents the builder state stays the same memory layout regardless of if a field has been initialized or not. 
+
+This does not require any unsafe code!
+
 ## 0.3.2 - 2022-06-09
 
 [#60](https://github.com/BrynCooke/buildstructor/issues/55)

--- a/src/buildstructor/codegen.rs
+++ b/src/buildstructor/codegen.rs
@@ -174,7 +174,7 @@ pub fn codegen(ir: Ir) -> Result<TokenStream> {
             }
 
             #builder_vis struct __Required<T> {
-                _phantom: std::marker::PhantomData<T>,
+                _uninit: std::mem::MaybeUninit<T>,
             }
             #builder_vis struct __Optional<T> {
                 lazy: Option<T>,
@@ -191,7 +191,7 @@ pub fn codegen(ir: Ir) -> Result<TokenStream> {
             #[inline(always)]
             fn __required<T>() -> __Required<T> {
                 __Required::<T> {
-                    _phantom: core::default::Default::default(),
+                    _uninit: std::mem::MaybeUninit::uninit(),
                 }
             }
 

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__async_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__async_test.snap
@@ -21,7 +21,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -36,7 +36,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_generics_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_generics_test.snap
@@ -27,7 +27,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -42,7 +42,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_generics_test2.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_generics_test2.snap
@@ -36,7 +36,7 @@ mod __collections_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -51,7 +51,7 @@ mod __collections_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_option_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_option_test.snap
@@ -23,7 +23,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -38,7 +38,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_test.snap
@@ -44,7 +44,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -59,7 +59,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__doc.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__doc.snap
@@ -22,7 +22,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -37,7 +37,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__fallible_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__fallible_test.snap
@@ -21,7 +21,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -36,7 +36,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__generic_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__generic_test.snap
@@ -22,7 +22,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -37,7 +37,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__into_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__into_test.snap
@@ -25,7 +25,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -40,7 +40,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__into_where_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__into_where_test.snap
@@ -22,7 +22,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -37,7 +37,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__lifetime.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__lifetime.snap
@@ -25,7 +25,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -40,7 +40,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__multi_field_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__multi_field_test.snap
@@ -23,7 +23,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -38,7 +38,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__multiple_generics_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__multiple_generics_test.snap
@@ -39,7 +39,7 @@ mod __request_fake_new_builder {
         }
     }
     pub struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub struct __Optional<T> {
         lazy: Option<T>,
@@ -54,7 +54,7 @@ mod __request_fake_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__option_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__option_test.snap
@@ -23,7 +23,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -38,7 +38,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__pub_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__pub_test.snap
@@ -21,7 +21,7 @@ mod __foo_new_builder {
         }
     }
     pub struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub struct __Optional<T> {
         lazy: Option<T>,
@@ -36,7 +36,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__reference.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__reference.snap
@@ -23,7 +23,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -38,7 +38,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__returns_self_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__returns_self_test.snap
@@ -21,7 +21,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -36,7 +36,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver-2.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver-2.snap
@@ -27,7 +27,7 @@ mod __client_call_with_no_return_ref_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -42,7 +42,7 @@ mod __client_call_with_no_return_ref_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver-3.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver-3.snap
@@ -24,7 +24,7 @@ mod __client_call_with_return_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -39,7 +39,7 @@ mod __client_call_with_return_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver-4.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver-4.snap
@@ -25,7 +25,7 @@ mod __client_call_with_return_ref_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -40,7 +40,7 @@ mod __client_call_with_return_ref_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver.snap
@@ -24,7 +24,7 @@ mod __client_call_with_no_return_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -39,7 +39,7 @@ mod __client_call_with_no_return_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_reference.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_reference.snap
@@ -20,7 +20,7 @@ mod __client_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -35,7 +35,7 @@ mod __client_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__single_field_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__single_field_test.snap
@@ -21,7 +21,7 @@ mod __foo_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -36,7 +36,7 @@ mod __foo_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__specialization.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__specialization.snap
@@ -1,6 +1,5 @@
 ---
 source: src/buildstructor/codegen.rs
-assertion_line: 641
 expression: output
 ---
 impl Foo<usize> {
@@ -22,7 +21,7 @@ mod __foo_bound_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -37,7 +36,7 @@ mod __foo_bound_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__specialization_self.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__specialization_self.snap
@@ -1,6 +1,5 @@
 ---
 source: src/buildstructor/codegen.rs
-assertion_line: 648
 expression: output
 ---
 impl Foo<usize> {
@@ -22,7 +21,7 @@ mod __foo_bound_new_builder {
         }
     }
     pub(super) struct __Required<T> {
-        _phantom: std::marker::PhantomData<T>,
+        _uninit: std::mem::MaybeUninit<T>,
     }
     pub(super) struct __Optional<T> {
         lazy: Option<T>,
@@ -37,7 +36,7 @@ mod __foo_bound_new_builder {
     #[inline(always)]
     fn __required<T>() -> __Required<T> {
         __Required::<T> {
-            _phantom: core::default::Default::default(),
+            _uninit: std::mem::MaybeUninit::uninit(),
         }
     }
     #[inline(always)]


### PR DESCRIPTION
Change the absence of a required variable to MaybeUninit. This means that the memory layout can stay the same throughout the entire builder lifecycle.