### PR TITLE
Add the ability to override builder visibility.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.3.3 - Unreleased
+[#70](https://github.com/BrynCooke/buildstructor/issues/70)
+Add the ability to override the visibility of generated builder.
 
 [#3](https://github.com/BrynCooke/buildstructor/issues/3)
 Changed the storage of required but not yet supplied values to use MaybeUninit.

--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ Collections are matched by type name:
 | ...Map    | insert(_, _)          |
 | Vec       | push(_)               |
 
-If your type does not conform to these patterns then you can use a type alias to trick buildstructor into giving the parameter special treatment.
+If your type does not conform to these patterns then you can use a type alias to trick Buildstructor into giving the parameter special treatment.
 
 #### Naming
 
@@ -339,6 +339,37 @@ To provide more control over generated builders and allow builders for methods w
 1. Annotate the impl with: `#[buildstructor::buildstructor]`
 2. Annotate methods to create a builders for with: `#[builder]`
 
+### Visibility
+
+Builders will automatically inherit the visibility of the method that they are decorating. However, if you want to override this then you can use the visibility.
+Valid values are :
+* `pub`
+* `pub (crate)`
+
+This is useful if you want Buildstructor builders to be the sole entry point for creating your struct.
+
+```rust
+use std::error::Error;
+
+pub mod foo {
+    pub struct MyStruct {
+        pub param: usize
+    }
+    
+    #[buildstructor::buildstructor]
+    impl MyStruct {
+        #[builder(visibility = "pub")]
+        fn new(param: usize) -> MyStruct {
+            Self { param }
+        }
+    }
+}
+
+fn main() {
+    let mine = foo::MyStruct::builder().param(2).build();
+    assert_eq!(mine.param, 2);
+}
+```
 
 ## TODO
 * Better error messages.

--- a/examples/visibility_override.rs
+++ b/examples/visibility_override.rs
@@ -1,0 +1,47 @@
+mod sub1 {
+    pub(crate) struct Foo {
+        pub simple: Bar1,
+    }
+
+    pub(crate) struct Bar1 {
+        pub(crate) simple: usize,
+    }
+
+    #[buildstructor::buildstructor]
+    impl Foo {
+        #[builder(visibility = "pub (crate)")]
+        fn new(simple: Bar1) -> Self {
+            Self { simple }
+        }
+    }
+}
+
+mod sub2 {
+    pub struct Foo {
+        pub simple: Bar2,
+    }
+
+    pub struct Bar2 {
+        pub(crate) simple: usize,
+    }
+
+    #[buildstructor::buildstructor]
+    impl Foo {
+        #[builder(visibility = "pub")]
+        fn new(simple: Bar2) -> Self {
+            Self { simple }
+        }
+    }
+}
+
+fn main() {
+    let sub1 = sub1::Foo::builder()
+        .simple(sub1::Bar1 { simple: 1 })
+        .build();
+    let sub2 = sub2::Foo::builder()
+        .simple(sub2::Bar2 { simple: 2 })
+        .build();
+
+    assert_eq!(sub1.simple.simple, 1);
+    assert_eq!(sub2.simple.simple, 2);
+}

--- a/src/buildstructor/analyze.rs
+++ b/src/buildstructor/analyze.rs
@@ -68,6 +68,7 @@ pub struct BuilderConfig {
     pub entry: Option<String>,
     pub exit: Option<String>,
     pub span: Option<Span>,
+    pub visibility: Option<String>,
 }
 
 impl TryFrom<&Attribute> for BuilderConfig {
@@ -87,9 +88,19 @@ impl TryFrom<&Attribute> for BuilderConfig {
                 ("exit", Lit::Str(value)) => {
                     config.exit = Some(value.value());
                 }
+                ("visibility", Lit::Str(value)) => {
+                    let value = value.value();
+                    if value != "pub" && value != "pub (crate)" {
+                        return Err(syn::Error::new(
+                            value.span(),
+                            "invalid builder attribute value for 'visibility', allowed values are 'pub' or 'pub (crate)",
+                        ));
+                    }
+                    config.visibility = Some(value);
+                }
                 _ => return Err(syn::Error::new(
                     value.span(),
-                    format!("invalid builder attribute '{}', only 'entry' and 'exit' are allowed and their type must be string", name),
+                    format!("invalid builder attribute '{}', only 'entry', 'exit' and 'visibility' are allowed and their type must be string", name),
                 )),
             }
             Ok(())

--- a/tests/buildstructor/pass/visibility_override.rs
+++ b/tests/buildstructor/pass/visibility_override.rs
@@ -1,0 +1,44 @@
+mod sub1 {
+    pub(crate) struct Foo {
+        simple: Bar1,
+    }
+
+    pub(crate) struct Bar1 {
+        pub(crate) simple: usize,
+    }
+
+    #[buildstructor::buildstructor]
+    impl Foo {
+        #[builder(visibility = "pub (crate)")]
+        fn new(simple: Bar1) -> Self {
+            Self { simple }
+        }
+    }
+}
+
+mod sub2 {
+    pub struct Foo {
+        simple: Bar2,
+    }
+
+    pub struct Bar2 {
+        pub(crate) simple: usize,
+    }
+
+    #[buildstructor::buildstructor]
+    impl Foo {
+        #[builder(visibility = "pub")]
+        fn new(simple: Bar2) -> Self {
+            Self { simple }
+        }
+    }
+}
+
+fn main() {
+    let _ = sub1::Foo::builder()
+        .simple(sub1::Bar1 { simple: 1 })
+        .build();
+    let _ = sub2::Foo::builder()
+        .simple(sub2::Bar2 { simple: 2 })
+        .build();
+}


### PR DESCRIPTION
Use:
`#[builder(visibility = "pub")]`

Valid values are:
* `pub`
* `pub (crate)`