### PR TITLE
Add derive support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.3.3 - Unreleased
+
+[#69](https://github.com/BrynCooke/buildstructor/issues/69)
+Add the ability to override the visibility of generated builder.
+
+```rust
+#[derive(buildstructor::Builder)]
+pub struct MyStruct {
+    simple: usize,
+}
+```
+
+The generated constructor will have private visibility and the builder will be public.
+
 [#70](https://github.com/BrynCooke/buildstructor/issues/70)
 Add the ability to override the visibility of generated builder.
 
@@ -19,7 +32,7 @@ This does not require any unsafe code!
 [#60](https://github.com/BrynCooke/buildstructor/issues/55)
 Fix impl with concrete types in generics where self is used in the return type.
 
-```
+```rust
 #[buildstructor]
 impl Foo<usize> {
     #[builder]
@@ -36,7 +49,7 @@ Previously the generated builder method was not including concrete generic type.
 [#60](https://github.com/BrynCooke/buildstructor/issues/55)
 Fix impl with concrete types in generics.
 
-```
+```rust
 #[buildstructor]
 impl Foo<usize> {
     #[builder]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ impl MyStruct {
         Self { sum: a + b }
     }
     
-    #[builder(entry = "more", exit = "add")]
+    #[builder(entry = "more", exit = "add", visibility="pub")]
     fn add_more(&mut self, c: usize, d: usize, e: Option<usize>) {
         self.sum += c + d + e.unwrap_or(3);
     }
@@ -48,9 +48,28 @@ fn main() {
 }
 ```
 
+## Derive usage
+
+For simple usage a default constructor and builder may be adequate. 
+Use `#[derive(buildstructor::Builder)]` to generate `fn new` that is annotated with `#[builder]`.  
+
+```rust
+#[derive(buildstructor::Builder)]
+pub struct MyStruct {
+    simple: usize,
+}
+
+fn main() {
+    let mut mine = MyStruct::builder().simple(2).build();
+    assert_eq!(mine.simple, 2);
+}
+```
+
+The generated constructor will have private visibility and the builder will match the visibility of the struct.
+
 ## Motivation
 
-The difference between this and other builder crates is that constructors/methods are used to derive builders rather than structs. This results in a more natural fit with regular Rust code, and no annotation magic to define behavior.
+The difference between this and other builder crates is that constructors/methods can be used to derive builders rather than structs. This results in a more natural fit with regular Rust code, and no annotation magic to define behavior.
 
 Advantages:
 

--- a/examples/derive.rs
+++ b/examples/derive.rs
@@ -1,0 +1,19 @@
+#[derive(buildstructor::Builder)]
+pub struct Single {
+    simple: usize,
+}
+
+mod sub {
+    #[derive(buildstructor::Builder)]
+    pub struct Generic<T> {
+        pub simple: T,
+    }
+}
+
+fn main() {
+    let single = Single::builder().simple(2).build();
+    assert_eq!(single.simple, 2);
+
+    let generic = sub::Generic::builder().simple(2).build();
+    assert_eq!(generic.simple, 2);
+}

--- a/tests/buildstructor/pass/derive.rs
+++ b/tests/buildstructor/pass/derive.rs
@@ -1,0 +1,14 @@
+#[derive(buildstructor::Builder)]
+pub struct Single {
+    simple: usize,
+}
+
+#[derive(buildstructor::Builder)]
+pub struct Generic<T> {
+    simple: T,
+}
+
+fn main() {
+    let _ = Single::builder().simple(2).build();
+    let _ = Generic::builder().simple(2).build();
+}


### PR DESCRIPTION
```rust
#[derive(buildstructor::Builder)]
pub struct MyStruct {
    simple: usize,
}
```

This will derive the following:

```rust
#[buildstructor::buildstructor]
pub impl MyStruct {
    #[builder(visibility="pub")]
    fn new(simple: usize)->MyStruct {
        Self {
          simple
        }
    }
}
```