### PR TITLE
Relax visibility override.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.2 - 2022-08-04
+
+[77](https://github.com/BrynCooke/buildstructor/issues/77)
+Remove validation of visibility specifier
+
 ## 0.4.0 - 2022-07-31
 
 [#69](https://github.com/BrynCooke/buildstructor/issues/69)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "buildstructor"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Bryn Cooke <bryncooke@gmail.com>"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -355,9 +355,6 @@ There had to be some magic somewhere.
 ### Visibility
 
 Builders will automatically inherit the visibility of the method that they are decorating. However, if you want to override this then you can use the visibility.
-Valid values are :
-* `pub`
-* `pub (crate)`
 
 This is useful if you want Buildstructor builders to be the sole entry point for creating your struct.
 

--- a/src/buildstructor/analyze.rs
+++ b/src/buildstructor/analyze.rs
@@ -90,12 +90,6 @@ impl TryFrom<&Attribute> for BuilderConfig {
                 }
                 ("visibility", Lit::Str(value)) => {
                     let value = value.value();
-                    if value != "pub" && value != "pub (crate)" {
-                        return Err(syn::Error::new(
-                            value.span(),
-                            "invalid builder attribute value for 'visibility', allowed values are 'pub' or 'pub (crate)",
-                        ));
-                    }
                     config.visibility = Some(value);
                 }
                 _ => return Err(syn::Error::new(

--- a/tests/buildstructor/pass/visibility_override.rs
+++ b/tests/buildstructor/pass/visibility_override.rs
@@ -9,7 +9,7 @@ mod sub1 {
 
     #[buildstructor::buildstructor]
     impl Foo {
-        #[builder(visibility = "pub (crate)")]
+        #[builder(visibility = "pub(crate)")]
         fn new(simple: Bar1) -> Self {
             Self { simple }
         }


### PR DESCRIPTION
Users may have complex visibility requirements, let them specify what they want.