### PR TITLE
fix: fix feature = "cargo-clippy" deprecation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ fn do_buildstructor(
 
 fn allow_many_params(ast: &mut Ast) {
     let allow_params: Attribute =
-        parse_quote!(#[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]);
+        parse_quote!(#[allow(clippy::too_many_arguments)]);
     ast.item.items.iter_mut().for_each(|item| {
         if let ImplItem::Fn(m) = item {
             if m.attrs


### PR DESCRIPTION
https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html