### PR TITLE
Emit modern #[allow(clippy::too_many_arguments)] syntax

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,8 +142,7 @@ fn do_buildstructor(
 }
 
 fn allow_many_params(ast: &mut Ast) {
-    let allow_params: Attribute =
-        parse_quote!(#[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]);
+    let allow_params: Attribute = parse_quote!(#[allow(clippy::too_many_arguments)]);
     ast.item.items.iter_mut().for_each(|item| {
         if let ImplItem::Fn(m) = item {
             if m.attrs


### PR DESCRIPTION
I guess `#[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]` might have worked once upon a time before lint namespacing was introduced, but Apollo Router using `#[allow(clippy::too_many_arguments)]` for several builders shows it hasn’t worked for a while.

Additionally, in Rust 1.85 there now a warning: ``warning: unexpected `cfg` condition value: `cargo-clippy` `` which links to https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html