### PR TITLE
Allow too many args update

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,13 @@ impl MyStruct {
     }
 }
 
-let mut mine = MyStruct::builder().a(2).b(3).build();
-assert_eq!(mine.sum, 5);
-
-mine.more().c(1).d(2).add();
-assert_eq!(mine.sum, 11);
+fn main() {
+    let mut mine = MyStruct::builder().a(2).b(3).build();
+    assert_eq!(mine.sum, 5);
+    
+    mine.more().c(1).d(2).add();
+    assert_eq!(mine.sum, 11);
+}
 ```
 
 ## Derive usage
@@ -60,8 +62,10 @@ pub struct MyStruct {
     simple: usize,
 }
 
-let mut mine = MyStruct::builder().simple(2).build();
-assert_eq!(mine.simple, 2);
+fn main() {
+    let mut mine = MyStruct::builder().simple(2).build();
+    assert_eq!(mine.simple, 2);
+}
 ```
 
 The generated constructor will have private visibility and the builder will match the visibility of the struct.
@@ -118,14 +122,16 @@ impl MyStruct {
     }
 }
 
-let mine = MyStruct::builder().simple(2).build();
-assert_eq!(mine.simple, 2);
+fn main() {
+    let mine = MyStruct::builder().simple(2).build();
+    assert_eq!(mine.simple, 2);
 
-let mine = MyStruct::try_builder().simple(2).build();
-assert_eq!(mine.simple, 2);
+    let mine = MyStruct::try_builder().simple(2).build();
+    assert_eq!(mine.simple, 2);
 
-let mine = MyStruct::random().simple(2).create();
-assert_eq!(mine.simple, 2);
+    let mine = MyStruct::random().simple(2).create();
+    assert_eq!(mine.simple, 2);
+}
 ```
 
 ### Methods
@@ -159,13 +165,15 @@ impl MyStruct {
     }
 }
 
-MyStruct::default().query().simple("3".to_string()).call(); // self
+fn main() {
+    MyStruct::default().query().simple("3".to_string()).call(); // self
 
-let mine = MyStruct::default();
-mine.query_ref().simple("3".to_string()).stop(); // &self
+    let mine = MyStruct::default();
+    mine.query_ref().simple("3".to_string()).stop(); // &self
 
-let mut mine = MyStruct::default();
-mine.query_ref_mut().simple("3".to_string()).go(); // &mut self
+    let mut mine = MyStruct::default();
+    mine.query_ref_mut().simple("3".to_string()).go(); // &mut self
+}
 ```
 
 ### Optional field
@@ -185,12 +193,14 @@ impl MyStruct {
     }
 }
 
-let mine = MyStruct::builder().param(2).build();
-assert_eq!(mine.param, 2);
-let mine = MyStruct::builder().and_param(Some(2)).build();
-assert_eq!(mine.param, 2);
-let mine = MyStruct::builder().build();
-assert_eq!(mine.param, 3);
+fn main() {
+    let mine = MyStruct::builder().param(2).build();
+    assert_eq!(mine.param, 2);
+    let mine = MyStruct::builder().and_param(Some(2)).build();
+    assert_eq!(mine.param, 2);
+    let mine = MyStruct::builder().build();
+    assert_eq!(mine.param, 3);
+}
 ```
 
 Note that if a field is an `Option` or collection then if a user forgets to set it a compile error will be generated.
@@ -221,8 +231,10 @@ impl MyStruct {
     }
 }
 
-let mine = MyStruct::builder().param("Hi").build();
-assert_eq!(mine.param, "Hi");
+fn main() {
+    let mine = MyStruct::builder().param("Hi").build();
+    assert_eq!(mine.param, "Hi");
+}
 ```
 
 ### Async
@@ -267,8 +279,10 @@ impl MyStruct {
     }
 }
 
-let mine = MyStruct::builder().param(2).build().unwrap();
-assert_eq!(mine.param, 2);
+fn main() {
+    let mine = MyStruct::builder().param(2).build().unwrap();
+    assert_eq!(mine.param, 2);
+}
 ```
 
 ### Collections and maps
@@ -289,15 +303,17 @@ impl MyStruct {
     }
 }
 
-let mine = MyStruct::builder()
-    .address("Amsterdam".to_string())
-    .address("Fakenham")
-    .addresses(vec!["Norwich".to_string(), "Bristol".to_string()])
-    .build();
-assert_eq!(mine.addresses, vec!["Amsterdam".to_string(), 
-                                "Fakenham".to_string(), 
-                                "Norwich".to_string(), 
-                                "Bristol".to_string()]);
+fn main() {
+    let mine = MyStruct::builder()
+        .address("Amsterdam".to_string())
+        .address("Fakenham")
+        .addresses(vec!["Norwich".to_string(), "Bristol".to_string()])
+        .build();
+    assert_eq!(mine.addresses, vec!["Amsterdam".to_string(), 
+                                    "Fakenham".to_string(), 
+                                    "Norwich".to_string(), 
+                                    "Bristol".to_string()]);
+}
 ```
 
 #### Supported types
@@ -359,8 +375,10 @@ pub mod foo {
     }
 }
 
-let mine = foo::MyStruct::builder().param(2).build();
-assert_eq!(mine.param, 2);
+fn main() {
+    let mine = foo::MyStruct::builder().param(2).build();
+    assert_eq!(mine.param, 2);
+}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,11 @@ impl MyStruct {
     }
 }
 
-fn main() {
-    let mut mine = MyStruct::builder().a(2).b(3).build();
-    assert_eq!(mine.sum, 5);
-    
-    mine.more().c(1).d(2).add();
-    assert_eq!(mine.sum, 11);
-}
+let mut mine = MyStruct::builder().a(2).b(3).build();
+assert_eq!(mine.sum, 5);
+
+mine.more().c(1).d(2).add();
+assert_eq!(mine.sum, 11);
 ```
 
 ## Derive usage
@@ -62,10 +60,8 @@ pub struct MyStruct {
     simple: usize,
 }
 
-fn main() {
-    let mut mine = MyStruct::builder().simple(2).build();
-    assert_eq!(mine.simple, 2);
-}
+let mut mine = MyStruct::builder().simple(2).build();
+assert_eq!(mine.simple, 2);
 ```
 
 The generated constructor will have private visibility and the builder will match the visibility of the struct.
@@ -122,16 +118,14 @@ impl MyStruct {
     }
 }
 
-fn main() {
-    let mine = MyStruct::builder().simple(2).build();
-    assert_eq!(mine.simple, 2);
+let mine = MyStruct::builder().simple(2).build();
+assert_eq!(mine.simple, 2);
 
-    let mine = MyStruct::try_builder().simple(2).build();
-    assert_eq!(mine.simple, 2);
+let mine = MyStruct::try_builder().simple(2).build();
+assert_eq!(mine.simple, 2);
 
-    let mine = MyStruct::random().simple(2).create();
-    assert_eq!(mine.simple, 2);
-}
+let mine = MyStruct::random().simple(2).create();
+assert_eq!(mine.simple, 2);
 ```
 
 ### Methods
@@ -165,15 +159,13 @@ impl MyStruct {
     }
 }
 
-fn main() {
-    MyStruct::default().query().simple("3".to_string()).call(); // self
+MyStruct::default().query().simple("3".to_string()).call(); // self
 
-    let mine = MyStruct::default();
-    mine.query_ref().simple("3".to_string()).stop(); // &self
+let mine = MyStruct::default();
+mine.query_ref().simple("3".to_string()).stop(); // &self
 
-    let mut mine = MyStruct::default();
-    mine.query_ref_mut().simple("3".to_string()).go(); // &mut self
-}
+let mut mine = MyStruct::default();
+mine.query_ref_mut().simple("3".to_string()).go(); // &mut self
 ```
 
 ### Optional field
@@ -193,14 +185,12 @@ impl MyStruct {
     }
 }
 
-fn main() {
-    let mine = MyStruct::builder().param(2).build();
-    assert_eq!(mine.param, 2);
-    let mine = MyStruct::builder().and_param(Some(2)).build();
-    assert_eq!(mine.param, 2);
-    let mine = MyStruct::builder().build();
-    assert_eq!(mine.param, 3);
-}
+let mine = MyStruct::builder().param(2).build();
+assert_eq!(mine.param, 2);
+let mine = MyStruct::builder().and_param(Some(2)).build();
+assert_eq!(mine.param, 2);
+let mine = MyStruct::builder().build();
+assert_eq!(mine.param, 3);
 ```
 
 Note that if a field is an `Option` or collection then if a user forgets to set it a compile error will be generated.
@@ -231,10 +221,8 @@ impl MyStruct {
     }
 }
 
-fn main() {
-    let mine = MyStruct::builder().param("Hi").build();
-    assert_eq!(mine.param, "Hi");
-}
+let mine = MyStruct::builder().param("Hi").build();
+assert_eq!(mine.param, "Hi");
 ```
 
 ### Async
@@ -279,10 +267,8 @@ impl MyStruct {
     }
 }
 
-fn main() {
-    let mine = MyStruct::builder().param(2).build().unwrap();
-    assert_eq!(mine.param, 2);
-}
+let mine = MyStruct::builder().param(2).build().unwrap();
+assert_eq!(mine.param, 2);
 ```
 
 ### Collections and maps
@@ -303,17 +289,15 @@ impl MyStruct {
     }
 }
 
-fn main() {
-    let mine = MyStruct::builder()
-        .address("Amsterdam".to_string())
-        .address("Fakenham")
-        .addresses(vec!["Norwich".to_string(), "Bristol".to_string()])
-        .build();
-    assert_eq!(mine.addresses, vec!["Amsterdam".to_string(), 
-                                    "Fakenham".to_string(), 
-                                    "Norwich".to_string(), 
-                                    "Bristol".to_string()]);
-}
+let mine = MyStruct::builder()
+    .address("Amsterdam".to_string())
+    .address("Fakenham")
+    .addresses(vec!["Norwich".to_string(), "Bristol".to_string()])
+    .build();
+assert_eq!(mine.addresses, vec!["Amsterdam".to_string(), 
+                                "Fakenham".to_string(), 
+                                "Norwich".to_string(), 
+                                "Bristol".to_string()]);
 ```
 
 #### Supported types
@@ -375,10 +359,8 @@ pub mod foo {
     }
 }
 
-fn main() {
-    let mine = foo::MyStruct::builder().param(2).build();
-    assert_eq!(mine.param, 2);
-}
+let mine = foo::MyStruct::builder().param(2).build();
+assert_eq!(mine.param, 2);
 ```
 
 

--- a/examples/self_builder.rs
+++ b/examples/self_builder.rs
@@ -31,14 +31,14 @@ impl Client {
 }
 
 fn main() {
-    Client::default().message().simple("3".to_string()).send();
-    Client::default().query().simple("3".to_string()).call();
+    Client.message().simple("3".to_string()).send();
+    Client.query().simple("3".to_string()).call();
 
-    let client = Client::default();
+    let client = Client;
     client.message_ref().simple("3".to_string()).send();
     client.query_ref().simple("3".to_string()).call();
 
-    let mut client = Client::default();
+    let mut client = Client;
     client.message_ref_mut().simple("3".to_string()).send();
     client.query_ref_mut().simple("3".to_string()).call();
 }

--- a/src/buildstructor/lower.rs
+++ b/src/buildstructor/lower.rs
@@ -93,7 +93,7 @@ pub fn lower(model: BuilderModel) -> Result<Ir> {
 
 // If the first parameter of a function is a reference it will have an implicit lifetime.
 fn implicit_lifetime(model: &BuilderModel) -> bool {
-    match model.delegate_args.get(0) {
+    match model.delegate_args.first() {
         None => {}
         Some(arg) => match arg {
             FnArg::Receiver(Receiver {

--- a/src/buildstructor/lower.rs
+++ b/src/buildstructor/lower.rs
@@ -39,7 +39,6 @@ pub struct BuilderField {
     pub ty: Type,
     pub ty_into: bool,
     pub generic_types: GenericTypes,
-    pub doc: Vec<Attribute>,
 }
 
 #[derive(Debug)]
@@ -202,7 +201,6 @@ fn builder_fields(model: &BuilderModel) -> Vec<BuilderField> {
                         .unwrap_or_else(|| ident.ident.clone()),
                     field_type,
                     generic_types,
-                    doc: vec![],
                 })
             }
             FnArg::Receiver(_) => None,

--- a/src/buildstructor/parse.rs
+++ b/src/buildstructor/parse.rs
@@ -1,17 +1,15 @@
 use proc_macro2::TokenStream;
 use syn::parse::{Parse, ParseStream};
-use syn::{parse2, Attribute, ItemImpl, Result};
+use syn::{parse2, ItemImpl, Result};
 
 #[derive(Clone, Debug)]
 pub struct Ast {
-    pub attributes: Vec<Attribute>,
     pub item: ItemImpl,
 }
 
 impl Parse for Ast {
     fn parse(input: ParseStream) -> Result<Self> {
         Ok(Ast {
-            attributes: input.call(Attribute::parse_outer)?,
             item: input.parse()?,
         })
     }

--- a/src/buildstructor/utils.rs
+++ b/src/buildstructor/utils.rs
@@ -64,7 +64,6 @@ pub trait GenericsExt {
     fn to_expr_tuple(&self, populate: impl Fn(usize, &TypeParam) -> Expr) -> ExprTuple;
     fn without(self, idx: usize) -> Self;
     fn combine(generics: Vec<&Generics>) -> Generics;
-    fn add_bound(self, ident: &Ident, ty: &Type) -> Self;
 }
 
 impl GenericsExt for Generics {
@@ -153,24 +152,6 @@ impl GenericsExt for Generics {
             ),
             ..Default::default()
         }
-    }
-
-    fn add_bound(mut self, ident: &Ident, ty: &Type) -> Self {
-        if let Some(ty) = ty.to_path() {
-            self.params.iter_mut().for_each(|p| {
-                if let GenericParam::Type(t) = p {
-                    if t.ident == *ident {
-                        t.bounds.push(TypeParamBound::Trait(TraitBound {
-                            paren_token: None,
-                            modifier: TraitBoundModifier::None,
-                            lifetimes: None,
-                            path: ty.clone(),
-                        }));
-                    }
-                }
-            });
-        }
-        self
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![allow(clippy::needless_doctest_main)]
 extern crate core;
 
 use proc_macro::TokenStream;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,7 +143,7 @@ fn do_buildstructor(
 
 fn allow_many_params(ast: &mut Ast) {
     let allow_params: Attribute =
-        parse_quote!(#[cfg_attr(feature = "cargo-clippy", allow(too_many_arguments))]);
+        parse_quote!(#[allow(clippy::too_many_arguments)]);
     ast.item.items.iter_mut().for_each(|item| {
         if let ImplItem::Fn(m) = item {
             if m.attrs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,8 +142,7 @@ fn do_buildstructor(
 }
 
 fn allow_many_params(ast: &mut Ast) {
-    let allow_params: Attribute =
-        parse_quote!(#[allow(clippy::too_many_arguments)]);
+    let allow_params: Attribute = parse_quote!(#[allow(clippy::too_many_arguments)]);
     ast.item.items.iter_mut().for_each(|item| {
         if let ImplItem::Fn(m) = item {
             if m.attrs


### PR DESCRIPTION
Rust allow too many args now requires:

```
#[allow(clippy::too_many_arguments)]
```
