### PR TITLE
Add #[must_use] to builder methods

### DIFF
--- a/src/buildstructor/codegen.rs
+++ b/src/buildstructor/codegen.rs
@@ -152,6 +152,7 @@ pub fn codegen(ir: Ir) -> Result<TokenStream> {
     Ok(quote! {
         impl #impl_generics #self_ty #where_clause {
             #(#doc)*
+            #[must_use]
             #vis fn #builder_entry #method_generics(#receiver) -> #builder_alias_name #builder_init_generic_args {
                 #module_name::new(#builder_receiver)
             }
@@ -165,6 +166,7 @@ pub fn codegen(ir: Ir) -> Result<TokenStream> {
             use super::*;
 
             #[inline(always)]
+            #[must_use]
             #builder_vis fn new #builder_init_generics(#builder_receiver_param) -> #builder_name #builder_init_generic_args_with_state
             {
                 #builder_name {
@@ -301,6 +303,7 @@ pub fn builder_methods(
                     quote! {
                         impl #builder_type_generics #builder_name #before {
                             #[inline(always)]
+                            #[must_use]
                             #builder_vis fn #method_name #into_generics(self, #field_name: #field_collection_type) -> #builder_name #after #builder_where_clause {
                                 let #field_name = Some(#field_name #into_call);
                                 #builder_name {
@@ -310,6 +313,7 @@ pub fn builder_methods(
                                 }
                             }
                             #[inline(always)]
+                            #[must_use]
                             #builder_vis fn #and_method_name #into_generics(self, #field_name: Option<#field_collection_type>) -> #builder_name #after #builder_where_clause {
                                 let #field_name = #field_name.map(|v|v #into_call);
                                 #builder_name {
@@ -340,12 +344,14 @@ pub fn builder_methods(
                         impl #builder_type_generics #builder_name #before {
 
                             #[inline(always)]
+                            #[must_use]
                             #builder_vis fn #plural (mut self, #field_name: #ty) -> #builder_name #before #builder_where_clause {
                                 self.fields.#index.lazy.get_or_insert_with(||core::default::Default::default()).extend(#field_name.into_iter());
                                 self
                             }
 
                             #[inline(always)]
+                            #[must_use]
                             #builder_vis fn #singular #into_generics(mut self, value: #field_collection_type) -> #builder_name #before #builder_where_clause{
                                 self.fields.#index.lazy.get_or_insert_with(||core::default::Default::default()).insert(value #into_call);
                                 self
@@ -374,12 +380,14 @@ pub fn builder_methods(
                         impl #builder_type_generics #builder_name #before {
 
                             #[inline(always)]
+                            #[must_use]
                             #builder_vis fn #plural (mut self, #field_name: #ty) -> #builder_name #before #builder_where_clause{
                                 self.fields.#index.lazy.get_or_insert_with(||core::default::Default::default()).extend(#field_name.into_iter());
                                 self
                             }
 
                             #[inline(always)]
+                            #[must_use]
                             #builder_vis fn #singular #into_generics(mut self, value: #field_collection_type) -> #builder_name #before #builder_where_clause{
                                 self.fields.#index.lazy.get_or_insert_with(||core::default::Default::default()).push(value #into_call);
                                 self
@@ -429,12 +437,14 @@ pub fn builder_methods(
                         impl #builder_type_generics #builder_name #before {
 
                             #[inline(always)]
+                            #[must_use]
                             #builder_vis fn #plural (mut self, #field_name: #ty) -> #builder_name #before #builder_where_clause{
                                 self.fields.#index.lazy.get_or_insert_with(||core::default::Default::default()).extend(#field_name.into_iter());
                                 self
                             }
 
                             #[inline(always)]
+                            #[must_use]
                             #builder_vis fn #singular #into_generics_final (mut self, key: #field_key_type, value: #field_value_type) -> #builder_name #before {
                                 self.fields.#index.lazy.get_or_insert_with(||core::default::Default::default()).insert(key #field_key_into_call, value #field_value_into_call);
                                 self
@@ -458,6 +468,7 @@ pub fn builder_methods(
                     quote! {
                         impl #builder_type_generics #builder_name #before {
                             #[inline(always)]
+                            #[must_use]
                             #builder_vis fn #method_name #into_generics(self, #field_name: #ty) -> #builder_name #after {
                                 let #field_name = #field_name #into_call;
                                 #builder_name {

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__associated_types.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__associated_types.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl<T: MyTrait> Foo<T> {
+    #[must_use]
     pub fn builder() -> NewFooBuilder<T> {
         __foo_new_builder::new()
     }
@@ -19,6 +20,7 @@ pub type NewFooBuilder<T: MyTrait> = __foo_new_builder::__FooBuilder<
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub fn new<T: MyTrait>() -> __FooBuilder<
         (
             __foo_new_builder::__Required<T>,
@@ -68,6 +70,7 @@ mod __foo_new_builder {
     }
     impl<__1, T: MyTrait> __FooBuilder<(__Required<T>, __1), T> {
         #[inline(always)]
+        #[must_use]
         pub fn foo(self, foo: T) -> __FooBuilder<(__Set<T>, __1), T> {
             let foo = foo;
             __FooBuilder {
@@ -78,6 +81,7 @@ mod __foo_new_builder {
     }
     impl<__0, T: MyTrait> __FooBuilder<(__0, __Required<T::Bar>), T> {
         #[inline(always)]
+        #[must_use]
         pub fn bar<__T: Into<T::Bar>>(self, bar: __T) -> __FooBuilder<(__0, __Set<T::Bar>), T> {
             let bar = bar.into();
             __FooBuilder {
@@ -93,4 +97,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__async_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__async_test.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo {
+    #[must_use]
     fn builder() -> NewFooBuilder {
         __foo_new_builder::new()
     }
@@ -13,6 +14,7 @@ type NewFooBuilder = __foo_new_builder::__FooBuilder<(__foo_new_builder::__Requi
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new() -> __FooBuilder<(__foo_new_builder::__Required<usize>,)> {
         __FooBuilder {
             fields: (__required(),),
@@ -56,6 +58,7 @@ mod __foo_new_builder {
     }
     impl __FooBuilder<(__Required<usize>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple(self, simple: usize) -> __FooBuilder<(__Set<usize>,)> {
             let simple = simple;
             __FooBuilder {
@@ -71,4 +74,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_generics_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_generics_test.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo {
+    #[must_use]
     fn builder<K: Into<String> + Eq + Hash, V: Into<String>>() -> NewFooBuilder<K, V> {
         __foo_new_builder::new()
     }
@@ -14,6 +15,7 @@ type NewFooBuilder<K: Into<String> + Eq + Hash, V: Into<String>> =
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new<K: Into<String> + Eq + Hash, V: Into<String>>(
     ) -> __FooBuilder<(__foo_new_builder::__Optional<HashMap<K, V>>,), K, V> {
         __FooBuilder {
@@ -60,6 +62,7 @@ mod __foo_new_builder {
         __FooBuilder<(__Optional<HashMap<K, V>>,), K, V>
     {
         #[inline(always)]
+        #[must_use]
         pub(super) fn param(
             mut self,
             param: HashMap<K, V>,
@@ -72,6 +75,7 @@ mod __foo_new_builder {
             self
         }
         #[inline(always)]
+        #[must_use]
         pub(super) fn param_entry(
             mut self,
             key: K,
@@ -94,4 +98,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_generics_test2.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_generics_test2.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Collections {
+    #[must_use]
     fn builder<K: Into<String> + Eq + Hash, V: Into<String>>() -> NewCollectionsBuilder<K, V> {
         __collections_new_builder::new()
     }
@@ -21,6 +22,7 @@ type NewCollectionsBuilder<K: Into<String> + Eq + Hash, V: Into<String>> =
 mod __collections_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new<K: Into<String> + Eq + Hash, V: Into<String>>() -> __CollectionsBuilder<
         (
             __collections_new_builder::__Optional<HashMap<K, V>>,
@@ -73,6 +75,7 @@ mod __collections_new_builder {
         __CollectionsBuilder<(__Optional<HashMap<K, V>>, __1), K, V>
     {
         #[inline(always)]
+        #[must_use]
         pub(super) fn map(
             mut self,
             map: HashMap<K, V>,
@@ -85,6 +88,7 @@ mod __collections_new_builder {
             self
         }
         #[inline(always)]
+        #[must_use]
         pub(super) fn map_entry(
             mut self,
             key: K,
@@ -102,6 +106,7 @@ mod __collections_new_builder {
         __CollectionsBuilder<(__0, __Optional<HashSet<K>>), K, V>
     {
         #[inline(always)]
+        #[must_use]
         pub(super) fn set(
             mut self,
             set: HashSet<K>,
@@ -114,6 +119,7 @@ mod __collections_new_builder {
             self
         }
         #[inline(always)]
+        #[must_use]
         pub(super) fn set_entry(
             mut self,
             value: K,
@@ -139,4 +145,3 @@ mod __collections_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_option_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_option_test.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo {
+    #[must_use]
     fn builder() -> NewFooBuilder {
         __foo_new_builder::new()
     }
@@ -15,6 +16,7 @@ type NewFooBuilder = __foo_new_builder::__FooBuilder<(
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new(
     ) -> __FooBuilder<(__foo_new_builder::__Optional<HashMap<Option<String>, Option<String>>>,)>
     {
@@ -60,6 +62,7 @@ mod __foo_new_builder {
     }
     impl __FooBuilder<(__Optional<HashMap<Option<String>, Option<String>>>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn param(
             mut self,
             param: HashMap<Option<String>, Option<String>>,
@@ -72,6 +75,7 @@ mod __foo_new_builder {
             self
         }
         #[inline(always)]
+        #[must_use]
         pub(super) fn param_entry(
             mut self,
             key: Option<String>,
@@ -92,4 +96,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__collection_test.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo {
+    #[must_use]
     fn builder() -> NewFooBuilder {
         __foo_new_builder::new()
     }
@@ -20,6 +21,7 @@ type NewFooBuilder = __foo_new_builder::__FooBuilder<(
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new() -> __FooBuilder<(
         __foo_new_builder::__Required<usize>,
         __foo_new_builder::__Optional<HashSet<String>>,
@@ -77,6 +79,7 @@ mod __foo_new_builder {
     }
     impl<__1, __2, __3, __4, __5> __FooBuilder<(__Required<usize>, __1, __2, __3, __4, __5)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple(
             self,
             simple: usize,
@@ -97,6 +100,7 @@ mod __foo_new_builder {
     }
     impl<__0, __2, __3, __4, __5> __FooBuilder<(__0, __Optional<HashSet<String>>, __2, __3, __4, __5)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn set(
             mut self,
             set: HashSet<String>,
@@ -109,6 +113,7 @@ mod __foo_new_builder {
             self
         }
         #[inline(always)]
+        #[must_use]
         pub(super) fn set_entry<__T: Into<String>>(
             mut self,
             value: __T,
@@ -125,6 +130,7 @@ mod __foo_new_builder {
         __FooBuilder<(__0, __1, __Optional<HashMap<String, String>>, __3, __4, __5)>
     {
         #[inline(always)]
+        #[must_use]
         pub(super) fn map(
             mut self,
             map: HashMap<String, String>,
@@ -137,6 +143,7 @@ mod __foo_new_builder {
             self
         }
         #[inline(always)]
+        #[must_use]
         pub(super) fn map_entry<__K: Into<String>, __V: Into<String>>(
             mut self,
             key: __K,
@@ -152,6 +159,7 @@ mod __foo_new_builder {
     }
     impl<__0, __1, __2, __4, __5> __FooBuilder<(__0, __1, __2, __Optional<Vec<String>>, __4, __5)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn vec(
             mut self,
             vec: Vec<String>,
@@ -164,6 +172,7 @@ mod __foo_new_builder {
             self
         }
         #[inline(always)]
+        #[must_use]
         pub(super) fn vec_entry<__T: Into<String>>(
             mut self,
             value: __T,
@@ -187,6 +196,7 @@ mod __foo_new_builder {
         )>
     {
         #[inline(always)]
+        #[must_use]
         pub(super) fn btmap(
             mut self,
             btmap: BTreeMap<String, String>,
@@ -206,6 +216,7 @@ mod __foo_new_builder {
             self
         }
         #[inline(always)]
+        #[must_use]
         pub(super) fn btmap_entry<__K: Into<String>, __V: Into<String>>(
             mut self,
             key: __K,
@@ -230,6 +241,7 @@ mod __foo_new_builder {
         __FooBuilder<(__0, __1, __2, __3, __4, __Optional<BTreeSet<String>>)>
     {
         #[inline(always)]
+        #[must_use]
         pub(super) fn btset(
             mut self,
             btset: BTreeSet<String>,
@@ -242,6 +254,7 @@ mod __foo_new_builder {
             self
         }
         #[inline(always)]
+        #[must_use]
         pub(super) fn btset_entry<__T: Into<String>>(
             mut self,
             value: __T,
@@ -276,4 +289,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__doc.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__doc.snap
@@ -4,6 +4,7 @@ expression: output
 ---
 impl Foo {
     #[doc = r" Test doc"]
+    #[must_use]
     fn builder() -> NewFooBuilder {
         __foo_new_builder::new()
     }
@@ -14,6 +15,7 @@ type NewFooBuilder = __foo_new_builder::__FooBuilder<(__foo_new_builder::__Requi
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new() -> __FooBuilder<(__foo_new_builder::__Required<usize>,)> {
         __FooBuilder {
             fields: (__required(),),
@@ -57,6 +59,7 @@ mod __foo_new_builder {
     }
     impl __FooBuilder<(__Required<usize>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple(self, simple: usize) -> __FooBuilder<(__Set<usize>,)> {
             let simple = simple;
             __FooBuilder {
@@ -72,4 +75,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__fallible_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__fallible_test.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo {
+    #[must_use]
     fn builder() -> NewFooBuilder {
         __foo_new_builder::new()
     }
@@ -13,6 +14,7 @@ type NewFooBuilder = __foo_new_builder::__FooBuilder<(__foo_new_builder::__Requi
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new() -> __FooBuilder<(__foo_new_builder::__Required<usize>,)> {
         __FooBuilder {
             fields: (__required(),),
@@ -56,6 +58,7 @@ mod __foo_new_builder {
     }
     impl __FooBuilder<(__Required<usize>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple(self, simple: usize) -> __FooBuilder<(__Set<usize>,)> {
             let simple = simple;
             __FooBuilder {
@@ -71,4 +74,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__generic_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__generic_test.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl<T> Foo<T> {
+    #[must_use]
     fn builder() -> NewFooBuilder<T> {
         __foo_new_builder::new()
     }
@@ -13,6 +14,7 @@ type NewFooBuilder<T> = __foo_new_builder::__FooBuilder<(__foo_new_builder::__Re
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new<T>() -> __FooBuilder<(__foo_new_builder::__Required<T>,), T> {
         __FooBuilder {
             fields: (__required(),),
@@ -56,6 +58,7 @@ mod __foo_new_builder {
     }
     impl<T> __FooBuilder<(__Required<T>,), T> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple(self, simple: T) -> __FooBuilder<(__Set<T>,), T> {
             let simple = simple;
             __FooBuilder {
@@ -71,4 +74,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__into_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__into_test.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo {
+    #[must_use]
     fn builder<T: Into<String>>() -> NewFooBuilder<T> {
         __foo_new_builder::new()
     }
@@ -14,6 +15,7 @@ type NewFooBuilder<T: Into<String>> =
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new<T: Into<String>>() -> __FooBuilder<(__foo_new_builder::__Required<T>,), T> {
         __FooBuilder {
             fields: (__required(),),
@@ -57,6 +59,7 @@ mod __foo_new_builder {
     }
     impl<T: Into<String>> __FooBuilder<(__Required<T>,), T> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple(self, simple: T) -> __FooBuilder<(__Set<T>,), T> {
             let simple = simple;
             __FooBuilder {
@@ -72,4 +75,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__into_where_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__into_where_test.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo {
+    #[must_use]
     fn builder<T>() -> NewFooBuilder<T> {
         __foo_new_builder::new()
     }
@@ -13,6 +14,7 @@ type NewFooBuilder<T> = __foo_new_builder::__FooBuilder<(__foo_new_builder::__Re
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new<T>() -> __FooBuilder<(__foo_new_builder::__Required<T>,), T> {
         __FooBuilder {
             fields: (__required(),),
@@ -56,6 +58,7 @@ mod __foo_new_builder {
     }
     impl<T> __FooBuilder<(__Required<T>,), T> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple(self, simple: T) -> __FooBuilder<(__Set<T>,), T> {
             let simple = simple;
             __FooBuilder {
@@ -74,4 +77,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__lifetime.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__lifetime.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl<'a> Foo<'a> {
+    #[must_use]
     fn builder() -> NewFooBuilder<'a> {
         __foo_new_builder::new()
     }
@@ -14,6 +15,7 @@ type NewFooBuilder<'a> =
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new<'a>() -> __FooBuilder<'a, (__foo_new_builder::__Required<&'a String>,)> {
         __FooBuilder {
             fields: (__required(),),
@@ -57,6 +59,7 @@ mod __foo_new_builder {
     }
     impl<'a> __FooBuilder<'a, (__Required<&'a String>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple(self, simple: &'a String) -> __FooBuilder<'a, (__Set<&'a String>,)> {
             let simple = simple;
             __FooBuilder {
@@ -72,4 +75,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__multi_field_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__multi_field_test.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo {
+    #[must_use]
     fn builder() -> NewFooBuilder {
         __foo_new_builder::new()
     }
@@ -16,6 +17,7 @@ type NewFooBuilder = __foo_new_builder::__FooBuilder<(
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new() -> __FooBuilder<(
         __foo_new_builder::__Required<usize>,
         __foo_new_builder::__Required<usize>,
@@ -62,6 +64,7 @@ mod __foo_new_builder {
     }
     impl<__1> __FooBuilder<(__Required<usize>, __1)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple(self, simple: usize) -> __FooBuilder<(__Set<usize>, __1)> {
             let simple = simple;
             __FooBuilder {
@@ -72,6 +75,7 @@ mod __foo_new_builder {
     }
     impl<__0> __FooBuilder<(__0, __Required<usize>)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple2(self, simple2: usize) -> __FooBuilder<(__0, __Set<usize>)> {
             let simple2 = simple2;
             __FooBuilder {
@@ -87,4 +91,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__multiple_generics_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__multiple_generics_test.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl<T> Request<T> {
+    #[must_use]
     pub fn fake_builder<K, V>() -> FakeNewRequestBuilder<T, K, V> {
         __request_fake_new_builder::new()
     }
@@ -23,6 +24,7 @@ pub type FakeNewRequestBuilder<T, K, V> = __request_fake_new_builder::__RequestB
 mod __request_fake_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub fn new<T, K, V>() -> __RequestBuilder<
         (
             __request_fake_new_builder::__Optional<Vec<(K, V)>>,
@@ -76,6 +78,7 @@ mod __request_fake_new_builder {
     }
     impl<__1, __2, __3, T, K, V> __RequestBuilder<(__Optional<Vec<(K, V)>>, __1, __2, __3), T, K, V> {
         #[inline(always)]
+        #[must_use]
         pub fn headers(
             mut self,
             headers: Vec<(K, V)>,
@@ -94,6 +97,7 @@ mod __request_fake_new_builder {
             self
         }
         #[inline(always)]
+        #[must_use]
         pub fn header(
             mut self,
             value: (K, V),
@@ -116,6 +120,7 @@ mod __request_fake_new_builder {
         __RequestBuilder<(__0, __Optional<Option<http::Uri>>, __2, __3), T, K, V>
     {
         #[inline(always)]
+        #[must_use]
         pub fn uri<__T: Into<http::Uri>>(
             self,
             uri: __T,
@@ -133,6 +138,7 @@ mod __request_fake_new_builder {
             }
         }
         #[inline(always)]
+        #[must_use]
         pub fn and_uri<__T: Into<http::Uri>>(
             self,
             uri: Option<__T>,
@@ -154,6 +160,7 @@ mod __request_fake_new_builder {
         __RequestBuilder<(__0, __1, __Optional<Option<http::Method>>, __3), T, K, V>
     {
         #[inline(always)]
+        #[must_use]
         pub fn method<__T: Into<http::Method>>(
             self,
             method: __T,
@@ -171,6 +178,7 @@ mod __request_fake_new_builder {
             }
         }
         #[inline(always)]
+        #[must_use]
         pub fn and_method<__T: Into<http::Method>>(
             self,
             method: Option<__T>,
@@ -190,6 +198,7 @@ mod __request_fake_new_builder {
     }
     impl<__0, __1, __2, T, K, V> __RequestBuilder<(__0, __1, __2, __Required<T>), T, K, V> {
         #[inline(always)]
+        #[must_use]
         pub fn body(self, body: T) -> __RequestBuilder<(__0, __1, __2, __Set<T>), T, K, V> {
             let body = body;
             __RequestBuilder {
@@ -224,4 +233,3 @@ mod __request_fake_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__option_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__option_test.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo {
+    #[must_use]
     fn builder() -> NewFooBuilder {
         __foo_new_builder::new()
     }
@@ -14,6 +15,7 @@ type NewFooBuilder =
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new() -> __FooBuilder<(__foo_new_builder::__Optional<Option<usize>>,)> {
         __FooBuilder {
             fields: (__optional(),),
@@ -57,6 +59,7 @@ mod __foo_new_builder {
     }
     impl __FooBuilder<(__Optional<Option<usize>>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn option(self, option: usize) -> __FooBuilder<(__Set<Option<usize>>,)> {
             let option = Some(option);
             __FooBuilder {
@@ -65,6 +68,7 @@ mod __foo_new_builder {
             }
         }
         #[inline(always)]
+        #[must_use]
         pub(super) fn and_option(
             self,
             option: Option<usize>,
@@ -83,4 +87,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__pub_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__pub_test.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo {
+    #[must_use]
     pub fn builder() -> NewFooBuilder {
         __foo_new_builder::new()
     }
@@ -13,6 +14,7 @@ pub type NewFooBuilder = __foo_new_builder::__FooBuilder<(__foo_new_builder::__R
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub fn new() -> __FooBuilder<(__foo_new_builder::__Required<usize>,)> {
         __FooBuilder {
             fields: (__required(),),
@@ -56,6 +58,7 @@ mod __foo_new_builder {
     }
     impl __FooBuilder<(__Required<usize>,)> {
         #[inline(always)]
+        #[must_use]
         pub fn simple(self, simple: usize) -> __FooBuilder<(__Set<usize>,)> {
             let simple = simple;
             __FooBuilder {
@@ -71,4 +74,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__reference.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__reference.snap
@@ -4,6 +4,7 @@ expression: output
 ---
 impl Foo {
     #[doc = r" Test doc"]
+    #[must_use]
     fn builder() -> NewFooBuilder {
         __foo_new_builder::new()
     }
@@ -15,6 +16,7 @@ type NewFooBuilder<'__a> =
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new() -> __FooBuilder<(__foo_new_builder::__Required<&usize>,)> {
         __FooBuilder {
             fields: (__required(),),
@@ -58,6 +60,7 @@ mod __foo_new_builder {
     }
     impl __FooBuilder<(__Required<&usize>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple(self, simple: &usize) -> __FooBuilder<(__Set<&usize>,)> {
             let simple = simple;
             __FooBuilder {
@@ -73,4 +76,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__returns_self_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__returns_self_test.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo {
+    #[must_use]
     fn builder() -> NewFooBuilder {
         __foo_new_builder::new()
     }
@@ -13,6 +14,7 @@ type NewFooBuilder = __foo_new_builder::__FooBuilder<(__foo_new_builder::__Requi
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new() -> __FooBuilder<(__foo_new_builder::__Required<usize>,)> {
         __FooBuilder {
             fields: (__required(),),
@@ -56,6 +58,7 @@ mod __foo_new_builder {
     }
     impl __FooBuilder<(__Required<usize>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple(self, simple: usize) -> __FooBuilder<(__Set<usize>,)> {
             let simple = simple;
             __FooBuilder {
@@ -71,4 +74,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver-2.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver-2.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Client {
+    #[must_use]
     fn message_ref(&self) -> CallWithNoReturnRefClientBuilder {
         __client_call_with_no_return_ref_builder::new(self)
     }
@@ -17,6 +18,7 @@ type CallWithNoReturnRefClientBuilder<'__a> =
 mod __client_call_with_no_return_ref_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new(
         receiver: &Client,
     ) -> __ClientBuilder<(__client_call_with_no_return_ref_builder::__Required<String>,)> {
@@ -64,6 +66,7 @@ mod __client_call_with_no_return_ref_builder {
     }
     impl<'__builder> __ClientBuilder<'__builder, (__Required<String>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple<__T: Into<String>>(
             self,
             simple: __T,
@@ -84,4 +87,3 @@ mod __client_call_with_no_return_ref_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver-3.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver-3.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Client {
+    #[must_use]
     fn query(self) -> CallWithReturnClientBuilder {
         __client_call_with_return_builder::new(self)
     }
@@ -15,6 +16,7 @@ type CallWithReturnClientBuilder = __client_call_with_return_builder::__ClientBu
 mod __client_call_with_return_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new(
         receiver: Client,
     ) -> __ClientBuilder<(__client_call_with_return_builder::__Required<String>,)> {
@@ -62,6 +64,7 @@ mod __client_call_with_return_builder {
     }
     impl __ClientBuilder<(__Required<String>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple<__T: Into<String>>(
             self,
             simple: __T,
@@ -81,4 +84,3 @@ mod __client_call_with_return_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver-4.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver-4.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Client {
+    #[must_use]
     fn query_ref(&self) -> CallWithReturnRefClientBuilder {
         __client_call_with_return_ref_builder::new(self)
     }
@@ -16,6 +17,7 @@ type CallWithReturnRefClientBuilder<'__a> = __client_call_with_return_ref_builde
 mod __client_call_with_return_ref_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new(
         receiver: &Client,
     ) -> __ClientBuilder<(__client_call_with_return_ref_builder::__Required<String>,)> {
@@ -63,6 +65,7 @@ mod __client_call_with_return_ref_builder {
     }
     impl<'__builder> __ClientBuilder<'__builder, (__Required<String>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple<__T: Into<String>>(
             self,
             simple: __T,
@@ -83,4 +86,3 @@ mod __client_call_with_return_ref_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_receiver.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Client {
+    #[must_use]
     fn message(self) -> CallWithNoReturnClientBuilder {
         __client_call_with_no_return_builder::new(self)
     }
@@ -15,6 +16,7 @@ type CallWithNoReturnClientBuilder = __client_call_with_no_return_builder::__Cli
 mod __client_call_with_no_return_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new(
         receiver: Client,
     ) -> __ClientBuilder<(__client_call_with_no_return_builder::__Required<String>,)> {
@@ -62,6 +64,7 @@ mod __client_call_with_no_return_builder {
     }
     impl __ClientBuilder<(__Required<String>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple<__T: Into<String>>(
             self,
             simple: __T,
@@ -82,4 +85,3 @@ mod __client_call_with_no_return_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_reference.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__self_reference.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Client {
+    #[must_use]
     fn builder(&self) -> NewClientBuilder {
         __client_new_builder::new(self)
     }
@@ -13,6 +14,7 @@ type NewClientBuilder<'__a> = __client_new_builder::__ClientBuilder<'__a, ()>;
 mod __client_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new(receiver: &Client) -> __ClientBuilder<()> {
         __ClientBuilder {
             receiver,
@@ -63,4 +65,3 @@ mod __client_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__single_field_test.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__single_field_test.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo {
+    #[must_use]
     fn builder() -> NewFooBuilder {
         __foo_new_builder::new()
     }
@@ -13,6 +14,7 @@ type NewFooBuilder = __foo_new_builder::__FooBuilder<(__foo_new_builder::__Requi
 mod __foo_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new() -> __FooBuilder<(__foo_new_builder::__Required<usize>,)> {
         __FooBuilder {
             fields: (__required(),),
@@ -56,6 +58,7 @@ mod __foo_new_builder {
     }
     impl __FooBuilder<(__Required<usize>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple(self, simple: usize) -> __FooBuilder<(__Set<usize>,)> {
             let simple = simple;
             __FooBuilder {
@@ -71,4 +74,3 @@ mod __foo_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__specialization.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__specialization.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo<usize> {
+    #[must_use]
     fn bound_builder() -> BoundNewFooBuilder {
         __foo_bound_new_builder::new()
     }
@@ -14,6 +15,7 @@ type BoundNewFooBuilder =
 mod __foo_bound_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new() -> __FooBuilder<(__foo_bound_new_builder::__Required<usize>,)> {
         __FooBuilder {
             fields: (__required(),),
@@ -57,6 +59,7 @@ mod __foo_bound_new_builder {
     }
     impl __FooBuilder<(__Required<usize>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple(self, simple: usize) -> __FooBuilder<(__Set<usize>,)> {
             let simple = simple;
             __FooBuilder {
@@ -72,4 +75,3 @@ mod __foo_bound_new_builder {
         }
     }
 }
-

--- a/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__specialization_self.snap
+++ b/src/buildstructor/snapshots/buildstructor__buildstructor__codegen__tests__specialization_self.snap
@@ -3,6 +3,7 @@ source: src/buildstructor/codegen.rs
 expression: output
 ---
 impl Foo<usize> {
+    #[must_use]
     fn bound_builder() -> BoundNewFooBuilder {
         __foo_bound_new_builder::new()
     }
@@ -14,6 +15,7 @@ type BoundNewFooBuilder =
 mod __foo_bound_new_builder {
     use super::*;
     #[inline(always)]
+    #[must_use]
     pub(super) fn new() -> __FooBuilder<(__foo_bound_new_builder::__Required<usize>,)> {
         __FooBuilder {
             fields: (__required(),),
@@ -57,6 +59,7 @@ mod __foo_bound_new_builder {
     }
     impl __FooBuilder<(__Required<usize>,)> {
         #[inline(always)]
+        #[must_use]
         pub(super) fn simple(self, simple: usize) -> __FooBuilder<(__Set<usize>,)> {
             let simple = simple;
             __FooBuilder {
@@ -72,4 +75,3 @@ mod __foo_bound_new_builder {
         }
     }
 }
-

--- a/tests/buildstructor/pass/must_use.rs
+++ b/tests/buildstructor/pass/must_use.rs
@@ -1,0 +1,16 @@
+use buildstructor::buildstructor;
+pub struct Foo {
+    simple: String,
+}
+
+#[buildstructor]
+impl Foo {
+    #[builder]
+    fn new(simple: String) -> Foo {
+        Self { simple }
+    }
+}
+
+fn main() {
+    Foo::builder().simple("3");
+}


### PR DESCRIPTION
Because builders don't do anything unless they are finished